### PR TITLE
avoid a division by zero

### DIFF
--- a/examples/01_dummy_training.py
+++ b/examples/01_dummy_training.py
@@ -100,7 +100,7 @@ def main(port: int = 8080, max_steps: int = 50, rendering_latency: float = 0.0):
         tic = time.time()
         with viewer.lock:
             num_train_rays_per_step = training_step()
-        num_train_steps_per_sec = 1.0 / (time.time() - tic)
+        num_train_steps_per_sec = 1.0 / (max(time.time() - tic, 1e-10))
         num_train_rays_per_sec = num_train_rays_per_step * num_train_steps_per_sec
         # Update the viewer state.
         viewer.render_tab_state.num_train_rays_per_sec = num_train_rays_per_sec

--- a/examples/04_gsplat_training.py
+++ b/examples/04_gsplat_training.py
@@ -631,7 +631,7 @@ class Runner:
 
             if not cfg.disable_viewer:
                 self.viewer.lock.release()
-                num_train_steps_per_sec = 1.0 / (time.time() - tic)
+                num_train_steps_per_sec = 1.0 / (max(time.time() - tic, 1e-10))
                 num_train_rays_per_sec = (
                     num_train_rays_per_step * num_train_steps_per_sec
                 )
@@ -822,7 +822,7 @@ class Runner:
             )  # [1, H, W, 3]
             colors = torch.clamp(colors, 0.0, 1.0)
             torch.cuda.synchronize()
-            ellipse_time += time.time() - tic
+            ellipse_time += max(time.time() - tic, 1e-10)
 
             # write images
             canvas = torch.cat([pixels, colors], dim=2).squeeze(0).cpu().numpy()

--- a/nerfview/_renderer.py
+++ b/nerfview/_renderer.py
@@ -171,7 +171,7 @@ class Renderer(threading.Thread):
                     else:
                         img, depth = rendered, None
                     self.viewer.render_tab_state.num_view_rays_per_sec = (W * H) / (
-                        time.time() - tic
+                        max(time.time() - tic, 1e-10)
                     )
             except InterruptRenderException:
                 continue


### PR DESCRIPTION
As discussed by #4 and #6,
```
/ (time.time() - tic)
```
leads to zero division.

The [latest upgrade](https://github.com/nerfstudio-project/nerfview/commit/d55d38bd1a3ff74991bae2b8d2927603291dc542#diff-4c35dbb262bb5fa861a8141deeed6a11abbb6eb7f5e5d348c4adddb6b91ad9e3R174) reverts this change. Please consider bringing it back.